### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/com/diffplug/common/base/Box.java
+++ b/src/com/diffplug/common/base/Box.java
@@ -49,7 +49,7 @@ public interface Box<T> extends Supplier<T>, Consumer<T> {
 
 	/** Creates a Box holding the given value. */
 	public static <T> Box<T> of(T value) {
-		return new Default<T>(value);
+		return new Default<>(value);
 	}
 
 	/** A simple implementation of Box. */
@@ -126,12 +126,12 @@ public interface Box<T> extends Supplier<T>, Consumer<T> {
 
 		/** Creates a Nullable of the given object. */
 		public static <T> Nullable<T> of(T init) {
-			return new Default<T>(init);
+			return new Default<>(init);
 		}
 
 		/** Creates an Nullable holding null. */
 		public static <T> Nullable<T> ofNull() {
-			return new Default<T>(null);
+			return new Default<>(null);
 		}
 
 		/** A simple implementation of Box.Nullable. */

--- a/src/com/diffplug/common/base/Either.java
+++ b/src/com/diffplug/common/base/Either.java
@@ -121,12 +121,12 @@ public interface Either<L, R> {
 
 	/** Creates an instance of Left. */
 	public static <L, R> Either<L, R> createLeft(L l) {
-		return new Left<L, R>(l);
+		return new Left<>(l);
 	}
 
 	/** Creates an instance of Right. */
 	public static <L, R> Either<L, R> createRight(R r) {
-		return new Right<L, R>(r);
+		return new Right<>(r);
 	}
 
 	/** Implementation of left. */

--- a/src/com/diffplug/common/base/Predicates.java
+++ b/src/com/diffplug/common/base/Predicates.java
@@ -90,7 +90,7 @@ public final class Predicates {
 	 * true}.
 	 */
 	public static <T> Predicate<T> and(Iterable<? extends Predicate<? super T>> components) {
-		return new AndPredicate<T>(defensiveCopy(components));
+		return new AndPredicate<>(defensiveCopy(components));
 	}
 
 	/**
@@ -104,7 +104,7 @@ public final class Predicates {
 	 */
 	@SafeVarargs
 	public static <T> Predicate<T> and(Predicate<? super T>... components) {
-		return new AndPredicate<T>(defensiveCopy(components));
+		return new AndPredicate<>(defensiveCopy(components));
 	}
 
 	/**
@@ -114,7 +114,7 @@ public final class Predicates {
 	 * predicate is found.
 	 */
 	public static <T> Predicate<T> and(Predicate<? super T> first, Predicate<? super T> second) {
-		return new AndPredicate<T>(Predicates.<T> asList(Objects.requireNonNull(first), Objects.requireNonNull(second)));
+		return new AndPredicate<>(Predicates.<T> asList(Objects.requireNonNull(first), Objects.requireNonNull(second)));
 	}
 
 	/**
@@ -127,7 +127,7 @@ public final class Predicates {
 	 * false}.
 	 */
 	public static <T> Predicate<T> or(Iterable<? extends Predicate<? super T>> components) {
-		return new OrPredicate<T>(defensiveCopy(components));
+		return new OrPredicate<>(defensiveCopy(components));
 	}
 
 	/**
@@ -141,7 +141,7 @@ public final class Predicates {
 	 */
 	@SafeVarargs
 	public static <T> Predicate<T> or(Predicate<? super T>... components) {
-		return new OrPredicate<T>(defensiveCopy(components));
+		return new OrPredicate<>(defensiveCopy(components));
 	}
 
 	/**
@@ -151,7 +151,7 @@ public final class Predicates {
 	 * true predicate is found.
 	 */
 	public static <T> Predicate<T> or(Predicate<? super T> first, Predicate<? super T> second) {
-		return new OrPredicate<T>(Predicates.<T> asList(Objects.requireNonNull(first), Objects.requireNonNull(second)));
+		return new OrPredicate<>(Predicates.<T> asList(Objects.requireNonNull(first), Objects.requireNonNull(second)));
 	}
 
 	/**
@@ -290,7 +290,7 @@ public final class Predicates {
 	}
 
 	static <T> List<T> defensiveCopy(Iterable<T> iterable) {
-		ArrayList<T> list = new ArrayList<T>();
+		ArrayList<T> list = new ArrayList<>();
 		for (T element : iterable) {
 			list.add(Objects.requireNonNull(element));
 		}

--- a/src/com/diffplug/common/base/Suppliers.java
+++ b/src/com/diffplug/common/base/Suppliers.java
@@ -63,7 +63,7 @@ public final class Suppliers {
 	 * memoize}, it is returned directly.
 	 */
 	public static <T> Supplier<T> memoize(Supplier<T> delegate) {
-		return (delegate instanceof MemoizingSupplier) ? delegate : new MemoizingSupplier<T>(Objects.requireNonNull(delegate));
+		return (delegate instanceof MemoizingSupplier) ? delegate : new MemoizingSupplier<>(Objects.requireNonNull(delegate));
 	}
 
 	@SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "It's a lightweight mechanism which ensures that delegate only gets called once.")
@@ -117,7 +117,7 @@ public final class Suppliers {
 	 * @since 2.0
 	 */
 	public static <T> Supplier<T> memoizeWithExpiration(Supplier<T> delegate, long duration, TimeUnit unit) {
-		return new ExpiringMemoizingSupplier<T>(delegate, duration, unit);
+		return new ExpiringMemoizingSupplier<>(delegate, duration, unit);
 	}
 
 	static class ExpiringMemoizingSupplier<T> implements Supplier<T> {
@@ -181,7 +181,7 @@ public final class Suppliers {
 	 * {@code delegate} before calling it, making it thread-safe.
 	 */
 	public static <T> Supplier<T> synchronizedSupplier(Supplier<T> delegate) {
-		return new ThreadSafeSupplier<T>(Objects.requireNonNull(delegate));
+		return new ThreadSafeSupplier<>(Objects.requireNonNull(delegate));
 	}
 
 	private static class ThreadSafeSupplier<T> implements Supplier<T> {

--- a/src/com/diffplug/common/base/TreeComparison.java
+++ b/src/com/diffplug/common/base/TreeComparison.java
@@ -141,7 +141,7 @@ public final class TreeComparison<E, A> {
 
 	/** Maps both sides of the comparison to the same type, for easier comparison and assertions. */
 	public <T> SameType<T> mapToSame(Function<? super E, ? extends T> mapExpected, Function<? super A, ? extends T> mapActual) {
-		return new SameTypeImp<E, A, T>(this, mapExpected, mapActual);
+		return new SameTypeImp<>(this, mapExpected, mapActual);
 	}
 
 	/** An API for comparing trees which have been mapped to the same type. */
@@ -194,13 +194,13 @@ public final class TreeComparison<E, A> {
 		/** Maps the variable on which the comparisons will take place. */
 		@Override
 		public <R> SameType<R> map(Function<? super T, ? extends R> mapper) {
-			return new SameTypeImp<E, A, R>(comparison, mapExpected.andThen(mapper), mapActual.andThen(mapper));
+			return new SameTypeImp<>(comparison, mapExpected.andThen(mapper), mapActual.andThen(mapper));
 		}
 	}
 
 	/** Creates a {@link TreeComparison} for comparing the two trees. */
 	public static <E, A> TreeComparison<E, A> of(TreeDef<E> expectedDef, E expectedRoot, TreeDef<A> actualDef, A actualRoot) {
-		return new TreeComparison<E, A>(expectedDef, expectedRoot, actualDef, actualRoot);
+		return new TreeComparison<>(expectedDef, expectedRoot, actualDef, actualRoot);
 	}
 
 	/** Creates a {@link SameType} for comparing two trees of the same type. */

--- a/src/com/diffplug/common/base/TreeNode.java
+++ b/src/com/diffplug/common/base/TreeNode.java
@@ -203,7 +203,7 @@ public class TreeNode<T> {
 		assert (test.size() > 0);
 		assert (0 == TreeNode.leadingSpaces(test.get(0)));
 
-		TreeNode<String> rootNode = new TreeNode<String>(null, test.get(0));
+		TreeNode<String> rootNode = new TreeNode<>(null, test.get(0));
 		TreeNode<String> lastNode = rootNode;
 		int lastSpaces = 0;
 
@@ -212,7 +212,7 @@ public class TreeNode<T> {
 			String name = test.get(i).substring(newSpaces);
 			if (newSpaces == lastSpaces + 1) {
 				// one level deeper, so the last guy should be the parent
-				lastNode = new TreeNode<String>(lastNode, name);
+				lastNode = new TreeNode<>(lastNode, name);
 				lastSpaces = newSpaces;
 			} else if (newSpaces <= lastSpaces) {
 				// any level back up, or the same level
@@ -221,7 +221,7 @@ public class TreeNode<T> {
 				for (int j = 0; j < diff; ++j) {
 					properParent = properParent.getParent();
 				}
-				lastNode = new TreeNode<String>(properParent, name);
+				lastNode = new TreeNode<>(properParent, name);
 				lastSpaces = newSpaces;
 			} else {
 				throw new IllegalArgumentException("Last element \"" + test.get(i - 1) + "\""


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
